### PR TITLE
include contributing guidelines as the last section in sphinx doc

### DIFF
--- a/docs/CONTRIBUTING.rst
+++ b/docs/CONTRIBUTING.rst
@@ -1,0 +1,1 @@
+../CONTRIBUTING.rst

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,6 +6,7 @@
 
     self
     api
+    CONTRIBUTING
 
 
 


### PR DESCRIPTION
in the context of #10

insert a last section in the sphinx doc

this relies on a symlink; it might be a caveat for some windows users, but as far as readthedocs at least, it should just do the job