### PR TITLE
more changes to allow to choose the name for the .csv and .png result files

### DIFF
--- a/paper/plot_timings.py
+++ b/paper/plot_timings.py
@@ -18,6 +18,9 @@ The timings.csv file contains the following columns:
     running out of memory.
 """
 
+from argparse import ArgumentParser
+from pathlib import Path
+
 import matplotlib.pyplot as plt
 import matplotlib.ticker as mticker
 import numpy as np
@@ -36,7 +39,7 @@ def remove_rows_where_all_values_except_time_are_same(df):
     ---------
     df : pd.DataFrame
         The input DataFrame.
-        
+
     Returns:
         pd.DataFrame: The DataFrame with duplicate rows removed.
     """
@@ -202,7 +205,13 @@ def plot_timings(
 
 
 if __name__ == "__main__":
-    df = pd.read_csv("timings/user_timings.csv")
+    parser = ArgumentParser()
+    parser.add_argument("-i", "--input", type=str, default="timings/user_timings.csv",
+                        help="Input file to read timings from.")
+    args = parser.parse_args()
+    output = Path(args.input).with_suffix(".png")
+
+    df = pd.read_csv(args.input)
     df = remove_rows_where_all_values_except_time_are_same(df)
 
     plt.rcParams.update({"font.size": 10})
@@ -429,7 +438,7 @@ if __name__ == "__main__":
         bbox_transform=plt.gcf().transFigure,
     )
     plt.gca().add_artist(first_legend)
-    
+
     ikpls_version_text = f"ikpls version: {ikpls.__version__}"
 
     fig.text(
@@ -457,4 +466,5 @@ if __name__ == "__main__":
     fig.patches.extend([rect1, rect2, rect11, rect12, rect21, rect22])
     # fig.tight_layout()
     plt.subplots_adjust(bottom=0.06, hspace=0.3, wspace=0.2, left=0.1, right=0.95)
-    plt.savefig(f"timings/user_timings.png")
+    plt.savefig(str(output))
+    print(f"output saved to {output}")

--- a/paper/reproducing-results-notebook.py
+++ b/paper/reproducing-results-notebook.py
@@ -26,8 +26,29 @@
 # these are used as a cache - i.e. not re-run if already present; you can simply delete or move this file if you want to re-start from scratch
 
 # %%
+# this one must not change
 REF_TIMINGS = "timings/timings.csv"
+
+# default - see next cell for how to change it
 OUR_TIMINGS = "timings/user_timings.csv"
+
+# %%
+# provide a way to choose the output from the command line
+# but argparse won't work from Jupyter, so:
+
+try:
+    # this is defined in a Jupyter / IPython environment
+    # in this case just change OUR_TIMINGS above
+    get_ipython()
+except:
+    # not in IPython/notebook - so we run from the command line
+    from argparse import ArgumentParser
+    parser = ArgumentParser()
+    parser.add_argument("-o", "--output", default=OUR_TIMINGS, help="filename for the csv output")
+    args = parser.parse_args()
+    OUR_TIMINGS = args.output
+
+print(f"using {OUR_TIMINGS=}")
 
 # %% [markdown]
 # ## loading the paper timings
@@ -109,7 +130,7 @@ if not len(previous):
 else:
     join = pd.merge(focus, previous, on=KEYS, how='left')
     missing = join[join.previous.isna()]
-    
+
 
 # %%
 missing


### PR DESCRIPTION
now that with @23 one can choose where to store the csv results, this allows to pass the filename as a parameter to plot_timings.py as well

rationale is to have a consistent naming scheme like e.g.
mac-timings.{csv,png}
linux-timings.{csv,png}
etc..

