### PR TITLE
a few convenience tweaks to make the reproduce script smoother

### DIFF
--- a/paper/reproducing-results-notebook.py
+++ b/paper/reproducing-results-notebook.py
@@ -43,6 +43,11 @@ DRY_RUN = False
 
 
 # %%
+# Allow JAX to use 64-bit floating point precision.
+import jax
+jax.config.update("jax_enable_x64", True)
+
+# %%
 # provide a way to choose the output from the command line
 # but argparse won't work from Jupyter, so:
 

--- a/paper/reproducing-results-notebook.py
+++ b/paper/reproducing-results-notebook.py
@@ -35,8 +35,8 @@ OUR_TIMINGS = "timings/user_timings.csv"
 # catch low-hanging fruits first
 SKIP_RUNS_LONGER_THAN = 0
 
-# by default, only on CPU
-RUN_ON_GPUS = False
+# by default, run all runs
+SKIP_GPU = False
 
 # 
 DRY_RUN = False
@@ -59,19 +59,19 @@ except:
     parser.add_argument("-s", "--skip-runs-longer-than", default=SKIP_RUNS_LONGER_THAN, 
                         action="store", type=int,
                         help="speed up: skip runs that had taken longer than, in seconds")
-    parser.add_argument("-g", "--gpu", default=RUN_ON_GPUS,
+    parser.add_argument("-g", "--skip-gpu", default=SKIP_GPU,
                         action="store_true",
-                        help="enable runs that require a GPU")
+                        help="skip runs that require a GPU")
     parser.add_argument("-n", "--dry-run", default=DRY_RUN,
                         action="store_true",
                         help="just show the commands to run, do not actually trigger them")
     args = parser.parse_args()
     OUR_TIMINGS = args.output
     SKIP_RUNS_LONGER_THAN = args.skip_runs_longer_than
-    RUN_RUN_ON_GPUS = args.gpu
+    SKIP_GPU = args.skip_gpu
     DRY_RUN = args.dry_run
 
-print(f"using {OUR_TIMINGS=} {SKIP_RUNS_LONGER_THAN=} {RUN_ON_GPUS=} {DRY_RUN=}")
+print(f"using {OUR_TIMINGS=} {SKIP_RUNS_LONGER_THAN=} {SKIP_GPU=} {DRY_RUN=}")
 
 # %% [markdown]
 # ## loading the paper timings
@@ -157,7 +157,7 @@ todo
 # ### isolating lines doable on a CPU (optional)
 
 # %%
-if not RUN_ON_GPUS:
+if SKIP_GPU:
     todo = todo[ ~ todo.model.str.contains('jax')]
 status("removed GPU-only runs")
 

--- a/paper/reproducing-results-notebook.py
+++ b/paper/reproducing-results-notebook.py
@@ -174,7 +174,7 @@ status("removed GPU-only runs")
 
 if SKIP_RUNS_LONGER_THAN:
     todo = todo[todo.time < SKIP_RUNS_LONGER_THAN]
-    status(f"keeping only runs shorter than {SKIP_RUNS_LONGER_THAN}s")
+    status(f"skipping runs over {SKIP_RUNS_LONGER_THAN}s")
 
 # %% [markdown]
 # ### ignore entries whose estimation cannot be automated

--- a/paper/time_pls.py
+++ b/paper/time_pls.py
@@ -15,6 +15,9 @@ from timings.timings import (
     single_fit_gpu_pls,
 )
 
+import jax
+jax.config.update("jax_enable_x64", True)
+
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument(


### PR DESCRIPTION
- the -g option was broken; now the default is to run all, with -g we skip runs that require a gpu
- configure jax for 64bits - just like the tests
